### PR TITLE
distutils: consistent PYTHON_COMPAT style

### DIFF
--- a/distutils.rst
+++ b/distutils.rst
@@ -70,7 +70,7 @@ The simplest case of ebuild is:
     EAPI=8
 
     DISTUTILS_USE_PEP517=setuptools
-    PYTHON_COMPAT=( python3_{8..10} pypy3  )
+    PYTHON_COMPAT=( python3_{8..10} pypy3 )
     inherit distutils-r1
 
     DESCRIPTION="Makes working with XML feel like you are working with JSON"
@@ -1152,7 +1152,7 @@ follows:
 
     DISTUTILS_USE_PEP517=flit
     DISTUTILS_OPTIONAL=1
-    PYTHON_COMPAT=( python3_{8..10} pypy3  )
+    PYTHON_COMPAT=( python3_{8..10} pypy3 )
 
     inherit distutils-r1
 


### PR DESCRIPTION
I have noticed those extra spaces while I was going through the text. It is totally minor think, but it follows recent change in https://github.com/gentoo/gentoo/commit/7a55b8993e05e8701b1913ef5040318f7533b081.
