### PR TITLE
pytest: Remove --ignore from EPYTEST_IGNORE example

### DIFF
--- a/pytest.rst
+++ b/pytest.rst
@@ -47,7 +47,7 @@ requires using the local scope.
     python_test() {
         local EPYTEST_IGNORE=(
             # ignore whole file with missing dep
-            --ignore tests/test_client.py
+            tests/test_client.py
         )
         local EPYTEST_DESELECT=(
             # deselect a single test


### PR DESCRIPTION
The --ignore parameter cannot be used in EPYTEST_IGNORE array otherwise
it makes the epytest to fail.

Fixes: 3e704006463b ("pytest: Switch to EPYTEST* vars")
Signed-off-by: Petr Vaněk <arkamar@atlas.cz>