### PR TITLE
Adapt examples to a modern python ebuild style

### DIFF
--- a/any.rst
+++ b/any.rst
@@ -90,7 +90,7 @@ This is best explained using an example:
     # Distributed under the terms of the GNU General Public License v2
 
     EAPI=6
-    PYTHON_COMPAT=( python3_{6,7,8} )
+    PYTHON_COMPAT=( python3_{10..13} )
 
     inherit meson python-any-r1
 
@@ -163,7 +163,7 @@ need to be wrapped in appropriate USE conditions:
 
     EAPI=7
 
-    PYTHON_COMPAT=( python3_{6,7} )
+    PYTHON_COMPAT=( python3_{10..13} )
     inherit python-any-r1
 
     DESCRIPTION="Programmable Completion for bash"
@@ -212,7 +212,7 @@ a similar condition in ``python_check_deps()``:
 
     EAPI=7
 
-    PYTHON_COMPAT=( python3_{6,7} )
+    PYTHON_COMPAT=( python3_{10..13} )
     inherit python-any-r1 cmake
 
     DESCRIPTION="Qt bindings for the Telepathy D-Bus protocol"

--- a/any.rst
+++ b/any.rst
@@ -22,14 +22,15 @@ build system that needs Python at build time could look like
 the following:
 
 .. code-block:: bash
-   :emphasize-lines: 6,7,21
+   :emphasize-lines: 6,8,21
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
-    PYTHON_COMPAT=( python3_{6..8} )
+    PYTHON_COMPAT=( python3_{10..13} )
+
     inherit python-any-r1
 
     DESCRIPTION="A repository of data files describing media player capabilities"
@@ -39,7 +40,6 @@ the following:
     LICENSE="BSD"
     SLOT="0"
     KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ppc ppc64 ~sh ~sparc x86"
-    IUSE=""
 
     RDEPEND=">=virtual/udev-208"
     DEPEND="${RDEPEND}"
@@ -86,10 +86,11 @@ This is best explained using an example:
 .. code-block:: bash
    :emphasize-lines: 19-22,25-28
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=6
+    EAPI=8
+
     PYTHON_COMPAT=( python3_{10..13} )
 
     inherit meson python-any-r1
@@ -101,7 +102,6 @@ This is best explained using an example:
     LICENSE="GPL-2+ LGPL-2+ FDL-1.1"
     SLOT="0"
     KEYWORDS="amd64 x86"
-    IUSE=""
 
     DEPEND="
         $(python_gen_any_dep '
@@ -156,14 +156,15 @@ the test suite.  In that case, the dependencies and ``pkg_setup`` call
 need to be wrapped in appropriate USE conditions:
 
 .. code-block:: bash
-   :emphasize-lines: 16,17,21-27,35
+   :emphasize-lines: 17,18,22-28,36
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
     PYTHON_COMPAT=( python3_{10..13} )
+
     inherit python-any-r1
 
     DESCRIPTION="Programmable Completion for bash"
@@ -177,7 +178,7 @@ need to be wrapped in appropriate USE conditions:
     RESTRICT="!test? ( test )"
 
     RDEPEND=">=app-shells/bash-4.3_p30-r1:0"
-    DEPEND="
+    BDEPEND="
         test? (
             ${RDEPEND}
             $(python_gen_any_dep '
@@ -205,14 +206,15 @@ and ``python_gen_any_dep`` in USE-conditional block, then express
 a similar condition in ``python_check_deps()``:
 
 .. code-block:: bash
-   :emphasize-lines: 16,19-24,27-30
+   :emphasize-lines: 17,21-26,29-32
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
     PYTHON_COMPAT=( python3_{10..13} )
+
     inherit python-any-r1 cmake
 
     DESCRIPTION="Qt bindings for the Telepathy D-Bus protocol"
@@ -225,7 +227,8 @@ a similar condition in ``python_check_deps()``:
     IUSE="test"
     RESTRICT="!test? ( test )"
 
-    BDEPEND="${PYTHON_DEPS}
+    BDEPEND="
+        ${PYTHON_DEPS}
         test? (
             $(python_gen_any_dep '
                 dev-python/dbus-python[${PYTHON_USEDEP}]
@@ -247,13 +250,14 @@ multiple possible ways of doing that, the least error-prone is to move
 USE conditional blocks inside ``python_gen_any_dep``:
 
 .. code-block:: bash
-   :emphasize-lines: 15,21-27,30-36,39
+   :emphasize-lines: 16,22-28,31-37,40
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=6
-    PYTHON_COMPAT=( python3_6 )
+    EAPI=8
+
+    PYTHON_COMPAT=( python3_{10..13} )
 
     inherit gnome2 python-any-r1
 
@@ -268,7 +272,7 @@ USE conditional blocks inside ``python_gen_any_dep``:
     # Tests fail with USE=-introspection, https://bugs.gentoo.org/655482
     REQUIRED_USE="test? ( introspection )"
 
-    DEPEND="
+    BDEPEND="
         test? (
             $(python_gen_any_dep '
                 dev-python/mock[${PYTHON_USEDEP}]

--- a/basic.rst
+++ b/basic.rst
@@ -25,7 +25,7 @@ The valid values are:
 
 Typical use::
 
-    PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
+    PYTHON_COMPAT=( python3_{10..13} pypy3 )
     inherit python-single-r1
 
 

--- a/buildsys.rst
+++ b/buildsys.rst
@@ -50,7 +50,7 @@ to inherit ``python-any-r1``.  The eclass takes care of setting
 
     EAPI=7
 
-    PYTHON_COMPAT=( python3_{6,7} )
+    PYTHON_COMPAT=( python3_{10..13} )
     inherit python-any-r1 scons-utils toolchain-funcs
 
     COMMIT="6e5e8a57628095d8d0c8bbb38187afb0f3a42112"
@@ -113,7 +113,7 @@ be combined.
 
     EAPI=7
 
-    PYTHON_COMPAT=( python3_{6,7} )
+    PYTHON_COMPAT=( python3_{10..13} )
     inherit python-any-r1 scons-utils toolchain-funcs
 
     MY_P=${PN}-src-r${PV/_rc/-rc}
@@ -286,7 +286,7 @@ unconditionally.
 
     EAPI=7
 
-    PYTHON_COMPAT=( python3_{6,7,8} )
+    PYTHON_COMPAT=( python3_{10..13} )
 
     FORTRAN_NEEDED=fortran
     FORTRAN_STANDARD=90

--- a/buildsys.rst
+++ b/buildsys.rst
@@ -304,7 +304,7 @@ unconditionally.
 
     REQUIRED_USE="
         ${PYTHON_REQUIRED_USE}
-        "
+    "
 
     RDEPEND="
         python? (

--- a/depend.rst
+++ b/depend.rst
@@ -22,13 +22,14 @@ the eclass to generate appropriate dependency string in ``PYTHON_DEPS``.
 .. code-block:: bash
    :emphasize-lines: 7
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
-    PYTHON_COMPAT=( python3_6 )
+    PYTHON_COMPAT=( python3_12 )
     PYTHON_REQ_USE="sqlite"
+
     inherit python-r1 gnome2-utils meson xdg-utils
 
     DESCRIPTION="Modern music player for GNOME"
@@ -38,7 +39,7 @@ the eclass to generate appropriate dependency string in ``PYTHON_DEPS``.
 
     LICENSE="GPL-3"
     SLOT="0"
-    REQUIRED_USE=${PYTHON_REQUIRED_USE}
+    REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
     DEPEND="${PYTHON_DEPS}
         ..."
@@ -47,20 +48,25 @@ Full USE dependency syntax is permitted.  For example, you can make
 the dependency conditional to a flag on the package:
 
 .. code-block:: bash
-   :emphasize-lines: 7,17
+   :emphasize-lines: 8,22
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=6
+    EAPI=8
 
-    PYTHON_COMPAT=( python3_6 )
+    DISTUTILS_USE_PEP517=setuptools
+    PYTHON_COMPAT=( python3_12 )
     PYTHON_REQ_USE="sqlite?"
+
     inherit distutils-r1
 
     DESCRIPTION="A lightweight password-manager with multiple database backends"
     HOMEPAGE="https://pwman3.github.io/pwman3/"
-    SRC_URI="https://github.com/pwman3/pwman3/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+    SRC_URI="
+        https://github.com/pwman3/pwman3/archive/v${PV}.tar.gz
+            -> ${P}.tar.gz
+    "
 
     LICENSE="GPL-3"
     SLOT="0"
@@ -74,33 +80,34 @@ helper then.  For example, the following ebuild requires Python with
 SQLite support when running tests:
 
 .. code-block:: bash
-   :emphasize-lines: 24
+   :emphasize-lines: 26
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
+
+    DISTUTILS_USE_PEP517=setuptools
     PYTHON_COMPAT=( python3_{10..13} pypy3 )
 
-    inherit distutils-r1
+    inherit distutils-r1 pypi
 
     DESCRIPTION="Let your Python tests travel through time"
-    HOMEPAGE="https://github.com/spulec/freezegun"
-    SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+    HOMEPAGE="
+        https://github.com/spulec/freezegun
+        https://pypi.org/project/freezegun/
+    "
 
     LICENSE="Apache-2.0"
     SLOT="0"
     KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos"
 
     RDEPEND="
-        >dev-python/python-dateutil-2.0[${PYTHON_USEDEP}]
-        dev-python/six[${PYTHON_USEDEP}]
+        >dev-python/python-dateutil-2.7[${PYTHON_USEDEP}]
     "
-    DEPEND="${RDEPEND}
-        dev-python/setuptools[${PYTHON_USEDEP}]
+    BDEPEND="
         test? (
             $(python_gen_impl_dep sqlite)
-            dev-python/mock[${PYTHON_USEDEP}]
         )
     "
 

--- a/depend.rst
+++ b/depend.rst
@@ -80,7 +80,7 @@ SQLite support when running tests:
     # Distributed under the terms of the GNU General Public License v2
 
     EAPI=7
-    PYTHON_COMPAT=( python{2_7,3_{6,7,8}} pypy3 )
+    PYTHON_COMPAT=( python3_{10..13} pypy3 )
 
     inherit distutils-r1
 

--- a/distutils-legacy.rst
+++ b/distutils-legacy.rst
@@ -269,21 +269,24 @@ steps inside that copy.  As a result, any changes done to the source
 files are contained within the copy used for the current interpreter.
 
 .. code-block:: bash
-   :emphasize-lines: 20
+   :emphasize-lines: 23
 
     # Copyright 1999-2020 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
     EAPI=7
+
     DISTUTILS_USE_SETUPTOOLS=no
     PYTHON_COMPAT=( python3_{10..13} pypy3 )
     PYTHON_REQ_USE="xml(+)"
 
-    inherit distutils-r1
+    inherit distutils-r1 pypi
 
     DESCRIPTION="Collection of extensions to Distutils"
-    HOMEPAGE="https://github.com/pypa/setuptools https://pypi.org/project/setuptools/"
-    SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.zip"
+    HOMEPAGE="
+        https://github.com/pypa/setuptools
+        https://pypi.org/project/setuptools/
+    "
 
     LICENSE="MIT"
     SLOT="0"

--- a/distutils-legacy.rst
+++ b/distutils-legacy.rst
@@ -72,7 +72,7 @@ The value needs to be set before inheriting the eclass:
 
     EAPI=7
 
-    PYTHON_COMPAT=( python2_7 python3_{6,7,8} pypy3 )
+    PYTHON_COMPAT=( python3_{10..13} pypy3 )
     DISTUTILS_USE_SETUPTOOLS=rdepend
 
     inherit distutils-r1
@@ -276,7 +276,7 @@ files are contained within the copy used for the current interpreter.
 
     EAPI=7
     DISTUTILS_USE_SETUPTOOLS=no
-    PYTHON_COMPAT=( python3_{6,7,8} pypy3 )
+    PYTHON_COMPAT=( python3_{10..13} pypy3 )
     PYTHON_REQ_USE="xml(+)"
 
     inherit distutils-r1

--- a/distutils.rst
+++ b/distutils.rst
@@ -58,25 +58,28 @@ for the build system.
 The simplest case of ebuild is:
 
 .. code-block:: bash
-   :emphasize-lines: 6-8
+   :emphasize-lines: 6-7,9
 
-    # Copyright 1999-2022 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
     EAPI=8
 
     DISTUTILS_USE_PEP517=setuptools
-    PYTHON_COMPAT=( python3_{8..10} pypy3 )
+    PYTHON_COMPAT=( python3_{10..13} pypy3 )
+
     inherit distutils-r1
 
-    DESCRIPTION="Makes working with XML feel like you are working with JSON"
-    HOMEPAGE="https://github.com/martinblech/xmltodict/ https://pypi.org/project/xmltodict/"
-    SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+    DESCRIPTION="A pure-Python memory-efficient packed representation for bit arrays"
+    HOMEPAGE="
+        https://engineering.purdue.edu/kak/dist/
+        https://pypi.org/project/BitVector/
+    "
+    SRC_URI="https://engineering.purdue.edu/kak/dist/${P}.tar.gz"
 
-    LICENSE="MIT"
+    LICENSE="PSF-2"
     SLOT="0"
-    KEYWORDS="~amd64 ~arm ~arm64 ~x86"
-
+    KEYWORDS="amd64 x86"
 
 .. _source archives:
 
@@ -191,39 +194,29 @@ the underlying eclass are not compatible — e.g. the dependencies need
 to be rewritten.
 
 .. code-block:: bash
-   :emphasize-lines: 9
+   :emphasize-lines: 6
 
-    # Copyright 1999-2022 Gentoo Authors
+    # Copyright 2023-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
-    PYTHON_COMPAT=( python3_{8..10} )
-    PYTHON_REQ_USE="readline"
-    DISTUTILS_USE_PEP517=setuptools
     DISTUTILS_SINGLE_IMPL=1
+    DISTUTILS_USE_PEP517=setuptools
+    PYTHON_COMPAT=( python3_{9..12} )
 
     inherit distutils-r1
 
-    DESCRIPTION="Pythonic layer on top of the ROOT framework's PyROOT bindings"
-    HOMEPAGE="http://rootpy.org"
-    SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+    DESCRIPTION="A utility to report core memory usage per program"
+    HOMEPAGE="https://github.com/pixelb/ps_mem"
+    SRC_URI="
+        https://github.com/pixelb/${PN}/archive/refs/tags/v${PV}.tar.gz
+            -> ${P}.tar.gz
+    "
 
-    LICENSE="BSD"
+    LICENSE="LGPL-2.1"
     SLOT="0"
-    KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
-
-    RDEPEND="
-        sci-physics/root:=[${PYTHON_SINGLE_USEDEP}]
-        dev-python/root_numpy[${PYTHON_SINGLE_USEDEP}]
-        $(python_gen_cond_dep '
-            dev-python/matplotlib[${PYTHON_USEDEP}]
-            dev-python/pytables[${PYTHON_USEDEP}]
-            dev-python/termcolor[${PYTHON_USEDEP}]
-        ')"
-
-    DEPEND="
-        sci-physics/root[${PYTHON_SINGLE_USEDEP}]"
+    KEYWORDS="amd64 ~arm64 ppc64 sparc x86"
 
 
 .. index:: DISTUTILS_USE_PEP517
@@ -782,22 +775,22 @@ containing Sphinx documentation:
 .. code-block:: bash
    :emphasize-lines: 24
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
     PYTHON_COMPAT=( python3_{10..13} )
-    DISTUTILS_USE_SETUPTOOLS=rdepend
+    DISTUTILS_USE_PEP517=setuptools
 
-    inherit distutils-r1
+    inherit distutils-r1 pypi
 
     DESCRIPTION="Colored stream handler for the logging module"
     HOMEPAGE="
         https://pypi.org/project/coloredlogs/
         https://github.com/xolox/python-coloredlogs
-        https://coloredlogs.readthedocs.io/en/latest/"
-    SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+        https://coloredlogs.readthedocs.io/en/latest/
+    "
 
     LICENSE="MIT"
     SLOT="0"
@@ -822,28 +815,40 @@ dependencies on the additional packages, pass them as extra arguments
 to ``distutils_enable_sphinx``.
 
 .. code-block:: bash
-   :emphasize-lines: 17-20
+   :emphasize-lines: 26-31
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
-    PYTHON_COMPAT=( pypy3 python3_{10..13} )
+    DISTUTILS_USE_PEP517=setuptools
+    PYTHON_COMPAT=( python3_{10..13} pypy3 )
+
     inherit distutils-r1
 
-    DESCRIPTION="Correctly inflect words and numbers"
-    HOMEPAGE="https://github.com/jazzband/inflect"
-    SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+    DESCRIPTION="A Python package for creating beautiful command line interfaces"
+    HOMEPAGE="
+        https://palletsprojects.com/p/click/
+        https://github.com/pallets/click/
+        https://pypi.org/project/click/
+    "
+    SRC_URI="
+        https://github.com/pallets/${PN}/archive/${PV}.tar.gz
+            -> ${P}.gh.tar.gz
+    "
 
-    LICENSE="MIT"
+    LICENSE="BSD"
     SLOT="0"
-    KEYWORDS="~amd64 ~arm64 ~ia64 ~ppc ~ppc64 ~x86"
+    KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-macos"
 
     distutils_enable_sphinx docs \
-        '>=dev-python/jaraco-packaging-3.2' \
-        '>=dev-python/rst-linker-1.9' \
-        dev-python/alabaster
+        '>=dev-python/docutils-0.14' \
+        dev-python/pallets-sphinx-themes \
+        dev-python/sphinxcontrib-log-cabinet \
+        dev-python/sphinx-issues \
+        dev-python/sphinx-tabs
+    distutils_enable_tests pytest
 
 In this case, the function uses the any-r1 API to request one
 of the supported implementations to be enabled on *all* of those
@@ -861,19 +866,22 @@ the ``--no-autodoc`` option can be specified instead of additional
 packages.
 
 .. code-block:: bash
-   :emphasize-lines: 17
+   :emphasize-lines: 20
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
     PYTHON_COMPAT=( python3_{10..13} )
-    inherit distutils-r1
+
+    inherit distutils-r1 pypi
 
     DESCRIPTION="Python Serial Port extension"
-    HOMEPAGE="https://github.com/pyserial/pyserial https://pypi.org/project/pyserial/"
-    SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+    HOMEPAGE="
+        https://github.com/pyserial/pyserial
+        https://pypi.org/project/pyserial/
+    "
 
     LICENSE="PSF-2"
     SLOT="0"
@@ -952,14 +960,14 @@ follows:
 .. code-block:: bash
    :emphasize-lines: 6-10,13-15,21-24,26-33,37,42,45-47,51,56
 
-    # Copyright 1999-2022 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
     EAPI=8
 
     DISTUTILS_USE_PEP517=flit
     DISTUTILS_OPTIONAL=1
-    PYTHON_COMPAT=( python3_{8..10} pypy3 )
+    PYTHON_COMPAT=( python3_{10..13} pypy3 )
 
     inherit distutils-r1
 
@@ -1162,10 +1170,10 @@ and PyPI wheel (for generated .dist-info) follows:
 .. code-block:: bash
    :emphasize-lines: 3,19,22
 
-    EAPI=7
+    EAPI=8
 
     DISTUTILS_USE_PEP517=no
-    PYTHON_COMPAT=( python3_{8..11} pypy3 )
+    PYTHON_COMPAT=( python3_{10..13} pypy3 )
 
     inherit distutils-r1
 
@@ -1202,10 +1210,10 @@ An example ebuild follows:
 .. code-block:: bash
    :emphasize-lines: 3,8,11-17
 
-    EAPI=7
+    EAPI=8
 
     DISTUTILS_USE_PEP517=no
-    PYTHON_COMPAT=( pypy3 python3_{8..11} )
+    PYTHON_COMPAT=( pypy3 python3_{10..13} )
 
     inherit distutils-r1
 
@@ -1237,7 +1245,7 @@ ebuild fragment demonstrates using it with Meson:
     EAPI=8
 
     DISTUTILS_USE_PEP517=no
-    PYTHON_COMPAT=( python3_{8..10} )
+    PYTHON_COMPAT=( python3_{10..13} )
 
     inherit meson distutils-r1
 

--- a/distutils.rst
+++ b/distutils.rst
@@ -787,7 +787,7 @@ containing Sphinx documentation:
 
     EAPI=7
 
-    PYTHON_COMPAT=( python3_{6,7,8} )
+    PYTHON_COMPAT=( python3_{10..13} )
     DISTUTILS_USE_SETUPTOOLS=rdepend
 
     inherit distutils-r1
@@ -829,7 +829,7 @@ to ``distutils_enable_sphinx``.
 
     EAPI=7
 
-    PYTHON_COMPAT=( pypy3 python3_{6,7,8} )
+    PYTHON_COMPAT=( pypy3 python3_{10..13} )
     inherit distutils-r1
 
     DESCRIPTION="Correctly inflect words and numbers"
@@ -868,7 +868,7 @@ packages.
 
     EAPI=7
 
-    PYTHON_COMPAT=( python2_7 python3_{6,7,8} )
+    PYTHON_COMPAT=( python3_{10..13} )
     inherit distutils-r1
 
     DESCRIPTION="Python Serial Port extension"

--- a/expert-multi.rst
+++ b/expert-multi.rst
@@ -37,7 +37,7 @@ dependencies to available targets.
 
     EAPI=7
 
-    PYTHON_COMPAT=( python2_7 python3_{6,7,8} pypy{,3} )
+    PYTHON_COMPAT=( python3_{10..13} pypy3 )
     PYTHON_REQ_USE="threads(+)"
     inherit distutils-r1
 
@@ -101,7 +101,7 @@ list.
 
     EAPI=7
 
-    PYTHON_COMPAT=( python3_{6,7,8} )
+    PYTHON_COMPAT=( python3_{6..8} )
     PYTHON_REQ_USE="sqlite"
     inherit distutils-r1
 
@@ -158,7 +158,7 @@ targets.
 
     EAPI=6
 
-    PYTHON_COMPAT=( python2_7 python3_{5,6,7} )
+    PYTHON_COMPAT=( python2_7 python3_{5..7} )
 
     inherit python-r1 toolchain-funcs
 

--- a/multi.rst
+++ b/multi.rst
@@ -332,7 +332,7 @@ that it is entirely normal that the same environment will be set inside
 
     EAPI="7"
 
-    PYTHON_COMPAT=( python{3_6,3_7} )
+    PYTHON_COMPAT=( python3_{10..13} )
     PYTHON_REQ_USE="ncurses,readline"
     inherit python-r1
 

--- a/single.rst
+++ b/single.rst
@@ -25,14 +25,15 @@ build system along with unconditional dependency on Python could look
 like the following:
 
 .. code-block:: bash
-   :emphasize-lines: 6,7,17,20
+   :emphasize-lines: 6,8,17,20
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
-    PYTHON_COMPAT=( python2_7 )
+    PYTHON_COMPAT=( python3_{10..13} )
+
     inherit python-single-r1
 
     DESCRIPTION="Scripts to prepare and plot VOACAP propagation predictions"
@@ -42,7 +43,6 @@ like the following:
     LICENSE="GPL-2+"
     SLOT="0"
     KEYWORDS="~amd64 ~x86"
-    IUSE=""
     REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
     RDEPEND="
@@ -116,14 +116,15 @@ conditionals need to be used in metadata variables, and ``pkg_setup``
 needs to be rewritten to call the default implementation conditionally:
 
 .. code-block:: bash
-   :emphasize-lines: 16,17,20,21,23-27,30,35
+   :emphasize-lines: 17,19,24,25,27-31,34,39
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=6
+    EAPI=8
 
-    PYTHON_COMPAT=( python2_7 )
+    PYTHON_COMPAT=( python3_{11..12} )
+
     inherit python-single-r1
 
     DESCRIPTION="Yet more Objects for (High Energy Physics) Data Analysis"
@@ -134,7 +135,10 @@ needs to be rewritten to call the default implementation conditionally:
     SLOT="0/${PV}"
     KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
     IUSE="python root"
-    REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+    REQUIRED_USE="
+        python? ( ${PYTHON_REQUIRED_USE} )
+        root? ( python )
+    "
 
     RDEPEND="
         python? ( ${PYTHON_DEPS} )
@@ -167,12 +171,12 @@ is expressed unconditionally, and the runtime dependency is made
 USE-conditional:
 
 .. code-block:: bash
-   :emphasize-lines: 18,19,23,26,32
+   :emphasize-lines: 18,19,23,30,38
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=6
+    EAPI=8
 
     PYTHON_COMPAT=( python3_{10..13} )
     PYTHON_REQ_USE="threads(+)"
@@ -191,10 +195,16 @@ USE-conditional:
 
     RDEPEND="
         ...
-        python? ( ${PYTHON_DEPS} )"
-    DEPEND="${RDEPEND}
+        python? ( ${PYTHON_DEPS} )
+    "
+    DEPEND="
+        ${RDEPEND}
         ...
-        ${PYTHON_DEPS}"
+    "
+    BDEPEND="
+        ${PYTHON_DEPS}
+        ...
+    "
 
     WAF_BINARY="${S}/buildtools/bin/waf"
 
@@ -215,14 +225,15 @@ for two independent conditions.  To make it more complex, one of them
 applies to build time (tests) while the other to runtime (bindings).
 
 .. code-block:: bash
-   :emphasize-lines: 16,19,20,24,27,31-33,38,39
+   :emphasize-lines: 17,20,21,25,28,32-34,39,40
 
     # Copyright 1999-2020 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
     PYTHON_COMPAT=( python3_{10..13} )
+
     inherit cmake python-single-r1
 
     DESCRIPTION="Sound design and signal processing system for composition and performance"
@@ -278,9 +289,10 @@ can be installed via one of the installation helpers.
     # Copyright 1999-2020 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=6
+    EAPI=8
 
-    PYTHON_COMPAT=( python2_7 )
+    PYTHON_COMPAT=( python3_{10..13} )
+
     inherit python-single-r1
 
     DESCRIPTION="Arabic dictionary based on the DICT protocol"
@@ -290,7 +302,6 @@ can be installed via one of the installation helpers.
     LICENSE="BSD"
     SLOT="0"
     KEYWORDS="~alpha amd64 ~hppa ~ia64 ~mips ~ppc ~sparc x86"
-    IUSE=""
     REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
     DEPEND="${PYTHON_DEPS}"

--- a/single.rst
+++ b/single.rst
@@ -174,7 +174,7 @@ USE-conditional:
 
     EAPI=6
 
-    PYTHON_COMPAT=( python3_{6,7,8} )
+    PYTHON_COMPAT=( python3_{10..13} )
     PYTHON_REQ_USE="threads(+)"
 
     inherit waf-utils python-single-r1
@@ -222,7 +222,7 @@ applies to build time (tests) while the other to runtime (bindings).
 
     EAPI=7
 
-    PYTHON_COMPAT=( python3_{6,7,8} )
+    PYTHON_COMPAT=( python3_{10..13} )
     inherit cmake python-single-r1
 
     DESCRIPTION="Sound design and signal processing system for composition and performance"

--- a/test.rst
+++ b/test.rst
@@ -28,27 +28,31 @@ dependencies and ``test`` USE flag if necessary.  If called after
 setting ``RDEPEND``, it also copies it to test dependencies.
 
 .. code-block:: bash
-   :emphasize-lines: 22
+   :emphasize-lines: 26
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
+    DISTUTILS_USE_PEP517=setuptools
     PYTHON_COMPAT=( python3_{10..13} pypy3 )
-    inherit distutils-r1
+
+    inherit distutils-r1 pypi
 
     DESCRIPTION="An easy whitelist-based HTML-sanitizing tool"
-    HOMEPAGE="https://github.com/mozilla/bleach https://pypi.org/project/bleach/"
-    SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+    HOMEPAGE="
+        https://github.com/mozilla/bleach/
+        https://pypi.org/project/bleach/
+    "
 
     LICENSE="Apache-2.0"
     SLOT="0"
     KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
 
     RDEPEND="
-        dev-python/six[${PYTHON_USEDEP}]
-        dev-python/webencodings[${PYTHON_USEDEP}]
+        dev-python/packaging[${PYTHON_USEDEP}]
+        >=dev-python/html5lib-1.0.1-r1[${PYTHON_USEDEP}]
     "
 
     distutils_enable_tests pytest
@@ -74,26 +78,32 @@ as ``distutils_enable_tests`` does that in the majority of cases.
 Please read the section on `undesirable test dependencies`_ too.
 
 .. code-block:: bash
-   :emphasize-lines: 18,21
+   :emphasize-lines: 22-24,27
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 2023-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=6
+    EAPI=8
 
-    PYTHON_COMPAT=( python3_{10..13} pypy3 )
-    inherit distutils-r1
+    DISTUTILS_USE_PEP517=hatchling
+    PYTHON_COMPAT=( python3_{10..13} )
 
-    DESCRIPTION="Universal encoding detector"
-    HOMEPAGE="https://github.com/chardet/chardet https://pypi.org/project/chardet/"
-    SRC_URI="https://github.com/chardet/chardet/archive/${PV}.tar.gz -> ${P}.tar.gz"
+    inherit distutils-r1 pypi
 
-    LICENSE="LGPL-2.1"
+    DESCRIPTION="Reusable constraint types to use with typing.Annotated"
+    HOMEPAGE="
+        https://github.com/annotated-types/annotated-types/
+        https://pypi.org/project/annotated-types/
+    "
+
+    LICENSE="MIT"
     SLOT="0"
-    KEYWORDS="~alpha amd64 arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 s390 ~sh sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~x64-macos ~x86-macos ~x64-solaris"
+    KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 
-    DEPEND="
-        test? ( dev-python/hypothesis[${PYTHON_USEDEP}] )
+    BDEPEND="
+        test? (
+            dev-python/pytest-mock[${PYTHON_USEDEP}]
+        )
     "
 
     distutils_enable_tests pytest
@@ -108,8 +118,10 @@ can be rewritten as:
 
     distutils_enable_tests pytest
 
-    DEPEND+="
-        test? ( dev-python/hypothesis[${PYTHON_USEDEP}] )
+    BDEPEND+="
+        test? (
+            dev-python/pytest-mock[${PYTHON_USEDEP}]
+        )
     "
 
 
@@ -131,19 +143,23 @@ they can be easily injected via overriding ``src_test()`` and making
 it call ``distutils-r1_src_test``:
 
 .. code-block:: bash
-   :emphasize-lines: 30-34
+   :emphasize-lines: 34-38
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
+    DISTUTILS_USE_PEP517=setuptools
     PYTHON_COMPAT=( python3_{10..13} )
-    inherit distutils-r1
+
+    inherit distutils-r1 virtualx pypi
 
     DESCRIPTION="Extra features for standard library's cmd module"
-    HOMEPAGE="https://github.com/python-cmd2/cmd2"
-    SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+    HOMEPAGE="
+        https://github.com/python-cmd2/cmd2/
+        https://pypi.org/project/cmd2/
+    "
 
     LICENSE="MIT"
     SLOT="0"
@@ -177,39 +193,40 @@ the former function simply defines a ``python_test()`` function as part
 of its logic.
 
 .. code-block:: bash
-   :emphasize-lines: 16,17,26-31,33-35
+   :emphasize-lines: 20,21,25-31,34-36
 
-    # Copyright 1999-2020 Gentoo Authors
+    # Copyright 1999-2024 Gentoo Authors
     # Distributed under the terms of the GNU General Public License v2
 
-    EAPI=7
+    EAPI=8
 
-    PYTHON_COMPAT=( python3_{6..8} pypy3 )
-    inherit distutils-r1
+    DISTUTILS_USE_PEP517=setuptools
+    PYTHON_COMPAT=( python3_{10..13} pypy3 )
+
+    inherit distutils-r1 pypi
 
     DESCRIPTION="Bash tab completion for argparse"
-    HOMEPAGE="https://pypi.org/project/argcomplete/"
-    SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+    HOMEPAGE="
+        https://github.com/kislyuk/argcomplete/
+        https://pypi.org/project/argcomplete/
+    "
 
     LICENSE="Apache-2.0"
     SLOT="0"
-    KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~x86 ~amd64-linux ~x86-linux ~x64-macos"
+    KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos"
     IUSE="test"
     RESTRICT="!test? ( test )"
 
-    RDEPEND="
-        $(python_gen_cond_dep '
-            <dev-python/importlib_metadata-2[${PYTHON_USEDEP}]
-        ' python3_{6..7} pypy3)"
     # pip is called as an external tool
     BDEPEND="
-        dev-python/setuptools[${PYTHON_USEDEP}]
         test? (
             app-shells/fish
             app-shells/tcsh
+            app-shells/zsh
             dev-python/pexpect[${PYTHON_USEDEP}]
-            dev-python/pip
-        )"
+            >=dev-python/pip-19
+        )
+    "
 
     python_test() {
         "${EPYTHON}" test/test.py -v || die

--- a/test.rst
+++ b/test.rst
@@ -35,7 +35,7 @@ setting ``RDEPEND``, it also copies it to test dependencies.
 
     EAPI=7
 
-    PYTHON_COMPAT=( python2_7 python3_{6,7,8} pypy3 )
+    PYTHON_COMPAT=( python3_{10..13} pypy3 )
     inherit distutils-r1
 
     DESCRIPTION="An easy whitelist-based HTML-sanitizing tool"
@@ -81,7 +81,7 @@ Please read the section on `undesirable test dependencies`_ too.
 
     EAPI=6
 
-    PYTHON_COMPAT=( python2_7 python3_{6,7,8} pypy3 )
+    PYTHON_COMPAT=( python3_{10..13} pypy3 )
     inherit distutils-r1
 
     DESCRIPTION="Universal encoding detector"
@@ -138,7 +138,7 @@ it call ``distutils-r1_src_test``:
 
     EAPI=7
 
-    PYTHON_COMPAT=( python3_{6,7,8} )
+    PYTHON_COMPAT=( python3_{10..13} )
     inherit distutils-r1
 
     DESCRIPTION="Extra features for standard library's cmd module"
@@ -184,7 +184,7 @@ of its logic.
 
     EAPI=7
 
-    PYTHON_COMPAT=( python{2_7,3_6,3_7,3_8} pypy3 )
+    PYTHON_COMPAT=( python3_{6..8} pypy3 )
     inherit distutils-r1
 
     DESCRIPTION="Bash tab completion for argparse"
@@ -200,7 +200,7 @@ of its logic.
     RDEPEND="
         $(python_gen_cond_dep '
             <dev-python/importlib_metadata-2[${PYTHON_USEDEP}]
-        ' -2 python3_{5,6,7} pypy3)"
+        ' python3_{6..7} pypy3)"
     # pip is called as an external tool
     BDEPEND="
         dev-python/setuptools[${PYTHON_USEDEP}]

--- a/test.rst
+++ b/test.rst
@@ -637,6 +637,9 @@ to allow interested users to run tests when possible::
 
 Tests aborting (due to assertions)
 ==================================
+
+.. highlight:: console
+
 There are cases of package's tests terminating with an unclear error
 message and backtrace similar to the following::
 


### PR DESCRIPTION
Sequence expression is commonly used for listing supported python implementations in `PYTHON_COMPAT` variable in ebuilds nowadays. This commit reflects that in all available examples for readers to see that this is the preferred method.